### PR TITLE
Capitalize Title

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,3 +1,3 @@
 {
-  "extension.openInBrowser.title": "open in default browser"
+  "extension.openInBrowser.title": "Open in Default Browser"
 }


### PR DESCRIPTION
The title should be capitalized to match other action items within VS code.